### PR TITLE
Fixes to successIndicator/BVP%INFO

### DIFF
--- a/scikits/bvp_solver/Solution.py
+++ b/scikits/bvp_solver/Solution.py
@@ -83,7 +83,7 @@ class Solution:
         read only, int
             Indicates success or failure of the solving operation.
         """
-        return self._yerror
+        return self._successIndicator
 
     @property
     def extended(self):
@@ -91,7 +91,7 @@ class Solution:
         read only, logical
             Indicates whether the solution has been extended.
         """
-        return self._yerror
+        return self._extended
 
     def __call__(self, points, eval_derivative = False):
         """Evaluates the approximate solution and optionally the first derivative at an array of points.
@@ -223,8 +223,8 @@ class Solution:
                       parameters = tools.fromf(bvp_object.parameters),
                       work = tools.fromf(bvp_object.work),
                       iwork = tools.fromf(bvp_object.iwork),
-                      yerror = bvp_object.yerror,
-                      successIndicator = bvp_object.info)
+                      yerror = tools.fromf(bvp_object.yerror),
+                      successIndicator = tools.fromf(bvp_object.info))
         return new
 
     @staticmethod

--- a/scikits/bvp_solver/lib/BVP_INTERFACE.f90
+++ b/scikits/bvp_solver/lib/BVP_INTERFACE.f90
@@ -73,7 +73,7 @@ function sol_from_params  (NODE_in,NPAR_in, LEFTBC_in ,NPTS_in,INFO_in, &
     	sol_out%LEFTBC = LEFTBC_in
 		sol_out%MXNSUB = MXNSUB_in
 		sol_out%NPTS = NPTS_in
-		sol_out%INFO = INFO
+		sol_out%INFO = INFO_in
 
 		sol_out%X => X_in
 		sol_out%Y => Y_in


### PR DESCRIPTION
successIndicator and yerror were not copied from bvp_object to
the Python Solution object, so multiple instances could have the
same object as these attributes.  Additionally, the successIndicator
was not properly copied back into FORTRAN.  Both caused problems
when calling bvp_solver functions after a failed solver run.

Also, the successIndicator and extended properties of Solution were
fixed to return the correct values.
