### PR TITLE
Python 3 fix

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -1,0 +1,11 @@
+TODO:
+
+1. Fixing installation on Windows:
+
+ImportError: DLL
+
+Workaround: need to copy the dll file to the directory that *.pyd lives:
+
+https://stackoverflow.com/questions/48826283/compile-fortran-module-with-f2py-and-python-3-6-on-windows-10
+
+

--- a/scikits/__init__.py
+++ b/scikits/__init__.py
@@ -1,2 +1,8 @@
 # Activate namespace packages.
 __import__('pkg_resources').declare_namespace(__name__)
+
+# Add path to dll library to PATH on Windows
+import os, sys
+if sys.platform == 'win32':
+    dllpath = os.path.join(os.path.dirname(__file__), '.libs')
+    os.environ['PATH'] += dllpath + ';'

--- a/scikits/bvp_solver/ComplexProblemDefinition.py
+++ b/scikits/bvp_solver/ComplexProblemDefinition.py
@@ -1,0 +1,177 @@
+import numpy as np
+from . import ProblemDefinition
+
+class ComplexProblemDefinition(ProblemDefinition):
+    """Defines a complex boundary value problem.
+        This is wrapper for complex differential equations:
+            dy/dx = f(x,y)
+            where x is real and y(x) and f can be complex. The original solver takes only real values, 
+            so we decompose the equations into real and imaginary parts. We use the following for a complex
+            vector y:
+
+            y=[y0, y1, ..., yN1] -> [y0.real,y1.real,...,yN1.real, y0.imag, y1.imag, ..., yN1.imag],
+
+            where yN1 is the N-th element of y.
+            
+            Linear ODEs:
+            For N linear ODEs, y' = My, where M
+            is a NxN matrix, we have 2 x N real equations. That is 
+            dy_big/dx = M_big y_big,
+            where y_big = [y_r, y_i] and 
+            M = [ M_r  -M_i ]
+                [ M_i   M_r ].
+
+        Note:
+        1. The class ``ComplexProblemDefinition" basically replaces ProblemDefinition and allows users to
+            define functions with complex arguments. 
+        2. The original ``solve" function is used. Therefore, the ``parameter_guess" argument for ``solve"
+            should be real. 
+    """
+
+    def __init__(self,
+                num_ODE_c,
+                num_parameters_c,
+                num_left_boundary_conditions_c,
+                boundary_points,
+                function_c,
+                boundary_conditions_c,
+                function_derivative_c = None,
+                boundary_conditions_derivative_c = None):
+        
+        self._num_ODE_c = num_parameters_c
+        self._num_parameters_c = num_parameters_c
+        self._num_left_boundary_conditions_c = num_left_boundary_conditions_c
+        self._function_c = function_c
+        self._boundary_conditions_c = boundary_conditions_c
+        self._function_derivative_c = function_derivative_c
+        self._boundary_conditions_derivative_c = boundary_conditions_derivative_c
+
+        if self._num_parameters_c == 0:
+            self._function_r = self._function_dummy
+            self._boundary_conditions_r = self._boundary_conditions_dummy
+            if self._function_derivative_c is None:
+                self._function_derivative_r = None
+            else:
+                self._function_derivative_r = self._function_derivative_dummy
+            if self._boundary_conditions_derivative_c is None:
+                self._boundary_conditions_derivative_r = None
+            else:
+                self._boundary_conditions_derivative_r = self._boundary_conditions_derivative_dummy
+            
+        else:
+            self._function_r = self._functionp_dummy
+            self._boundary_conditions_r = self._boundary_conditionsp_dummy
+
+            if self._function_derivative_c is None:
+                self._function_derivative_r = None
+            else:
+                self._function_derivative_r = self._function_derivativep_dummy
+
+            if self._boundary_conditions_derivative_c is None:
+                self._boundary_conditions_derivative_r = None
+            else:
+                self._boundary_conditions_derivative_r = self._boundary_conditionsp_derivative_dummy
+
+        ProblemDefinition.__init__(self,
+                num_ODE = num_ODE_c * 2,
+                num_parameters = num_parameters_c * 2,
+                num_left_boundary_conditions = num_left_boundary_conditions_c * 2,
+                boundary_points = boundary_points,
+                function = self._function_r,
+                boundary_conditions = self._boundary_conditions_r,
+                function_derivative = self._function_derivative_r,
+                boundary_conditions_derivative = self._boundary_conditions_derivative_r)
+
+    def _function_dummy(self, T, Y):
+        """dummy real function without parameter
+        """
+        dYc = self._function_c(T, real_to_complex(Y))
+        return complex_to_real(dYc)
+
+    def _functionp_dummy(self, T, P, Y):
+        """dummy real function with parameter
+        """
+        dYc = self._function_c(T, real_to_complex(P), real_to_complex(Y))
+        return complex_to_real(dYc)
+
+    def _boundary_conditions_dummy(self, Ya, Yb):
+        """dummy real BC without parameter
+        """
+        BCac, BCbc = self._boundary_conditions_c(
+            real_to_complex(Ya), 
+            real_to_complex(Yb))
+        return complex_to_real(BCac), complex_to_real(BCbc)
+
+    def _boundary_conditionsp_dummy(self, Ya, Yb, P):
+        """dummy real BC with parameter
+        """
+        BCac, BCbc = self._boundary_conditions_c(
+            real_to_complex(Ya), 
+            real_to_complex(Yb),
+            real_to_complex(P) )
+        return complex_to_real(BCac), complex_to_real(BCbc)
+
+    def _function_derivative_dummy(self, T, Y):
+        """function derivative w/o parameter
+        """
+        dFdYc = self._function_derivative_c(T, real_to_complex(Y))
+        return complex_to_real_matrix(dFdYc)
+
+    def _function_derivativep_dummy(self, T, Y, P):
+        """function derivative w/ parameter
+        """
+        dFdYc, dFdPc = self._function_derivative_c(T, real_to_complex(Y), real_to_complex(P))
+        return complex_to_real_matrix(dFdYc), complex_to_real_matrix(dFdPc)
+
+    def _boundary_conditions_derivative_dummy(self, Ya, Yb):
+        """boundary conditions derivative w/o parameter
+        """
+        dBCa, dBCb = self._boundary_conditions_derivative_c(
+                                real_to_complex(Ya), 
+                                real_to_complex(Yb))
+        return complex_to_real_matrix(dBCa), complex_to_real_matrix(dBCb)
+    
+    def _boundary_conditionsp_derivative_dummy(self, Ya, Yb, P):
+        """boundary conditions derivative w/ parameter
+        """
+
+        dBCa, dBCb, dBPa, dBPb = self._boundary_conditions_derivative_c(
+                                    real_to_complex(Ya), 
+                                    real_to_complex(Yb),
+                                    real_to_complex(P)
+                                    )
+        return complex_to_real_matrix(dBCa), complex_to_real_matrix(dBCb), \
+            complex_to_real_matrix(dBPa), complex_to_real_matrix(dBPb)
+
+# some helper functions
+def complex_to_real(Yc):
+    """convert a complex vector into real vector 
+    """
+    return np.hstack([Yc.real, Yc.imag])
+
+def real_to_complex(Y):
+    """convert a real vector into a complex vector
+    """
+    N = Y.shape[0]
+    return Y[:int(N/2)] + 1j*Y[int(N/2):]
+
+def complex_to_real_matrix(Mc):
+    """compute an ``enlarged" real matrix
+    """
+    dim1, dim2 = Mc.shape
+    M = np.zeros((dim1*2, dim2*2), dtype=float)
+    M[:dim1,:dim2] = Mc.real
+    M[:dim1,dim2:] =-Mc.imag
+    M[dim1:,:dim2] = Mc.imag
+    M[dim1:,dim2:] = Mc.real
+    return M
+
+def real_to_complex_matrix(M):
+    dim1, dim2 = M.shape
+    Mc = M[:int(dim1/2),:int(dim2/2)] - 1j * M[:int(dim1/2),int(dim2/2):]
+    return Mc
+
+
+
+
+

--- a/scikits/bvp_solver/ProblemDefinition.py
+++ b/scikits/bvp_solver/ProblemDefinition.py
@@ -1,5 +1,5 @@
 import numpy
-import tools
+from . import tools
 import pickle
 
 class ProblemDefinition:

--- a/scikits/bvp_solver/ProblemDefinition.py
+++ b/scikits/bvp_solver/ProblemDefinition.py
@@ -362,7 +362,7 @@ class ProblemDefinition:
         places = 4
 
         # chose the point near the middle of the test_solution to check the derivatives
-        middlePoint = numpy.round(test_solution.mesh.size * .61, 0)
+        middlePoint = int(numpy.round(test_solution.mesh.size * .61, 0))
 
 
         if self.has_function_derivative:

--- a/scikits/bvp_solver/Solution.py
+++ b/scikits/bvp_solver/Solution.py
@@ -1,6 +1,6 @@
 import numpy
-import tools
-import bvp_solverf
+from . import tools
+from . import bvp_solverf
 import pickle
 
 

--- a/scikits/bvp_solver/Solution.py
+++ b/scikits/bvp_solver/Solution.py
@@ -2,6 +2,7 @@ import numpy
 from . import tools
 from . import bvp_solverf
 import pickle
+import sys
 
 
 class Solution:
@@ -241,9 +242,14 @@ class Solution:
         sol : Solution
             Solution loaded from the file.
         """
-        loadfile = open(path, "r")
-        solution = pickle.load(loadfile)
-        loadfile.close()
+        if sys.version_info[0] < 3:
+            loadfile = open(path, "r")
+            solution = pickle.load(loadfile)
+            loadfile.close()
+        else:
+            loadfile = open(path, "rb")
+            solution = pickle.load(loadfile)
+            loadfile.close()
         return solution
 
     def save(self, path):
@@ -254,6 +260,11 @@ class Solution:
         path : string
             Path of the file to store the Solution in.
         """
-        savefile = open(path, "w")
-        pickle.dump(self, savefile)
-        savefile.close()
+        if sys.version_info[0] < 3:
+            savefile = open(path, "w")
+            pickle.dump(self, savefile)
+            savefile.close()
+        else:
+            savefile = open(path, "wb")
+            pickle.dump(self, savefile, protocol=2)
+            savefile.close()

--- a/scikits/bvp_solver/__init__.py
+++ b/scikits/bvp_solver/__init__.py
@@ -1,5 +1,6 @@
 from .solver import solve
 from .ProblemDefinition import ProblemDefinition
+from .ComplexProblemDefinition import ComplexProblemDefinition
 from .Solution import Solution
 from .template_generator import get_template
 

--- a/scikits/bvp_solver/__init__.py
+++ b/scikits/bvp_solver/__init__.py
@@ -1,5 +1,5 @@
-from solver import solve
-from ProblemDefinition import ProblemDefinition
-from Solution import Solution
-from template_generator import get_template
+from .solver import solve
+from .ProblemDefinition import ProblemDefinition
+from .Solution import Solution
+from .template_generator import get_template
 

--- a/scikits/bvp_solver/examples/ExampleC1.py
+++ b/scikits/bvp_solver/examples/ExampleC1.py
@@ -65,6 +65,8 @@ if __name__=='__main__':
     y = solution(x)
     print("lambda = " + str(solution.parameters[0]))
 
+    solution.save("test_ExampleC1.sol")
+
 
     fig = plt.figure()
     ax = fig.add_subplot(111)

--- a/scikits/bvp_solver/examples/ExampleC1.py
+++ b/scikits/bvp_solver/examples/ExampleC1.py
@@ -1,0 +1,75 @@
+import numpy as np 
+import matplotlib.pyplot as plt
+import scikits.bvp_solver as bvp
+#import ComplexProblemDefinition as cbvp
+import sys
+
+def function(X,Y,P):
+
+    k = P[0]
+    return np.array([ 1j*k*Y[1],
+                      1j*k*Y[0]])
+
+def function_derivative(X,Y,P):
+    dFdY = np.array([[     0.0 , 1j*P[0] ],
+                        [ 1j*P[0] ,     0.0 ]])
+    dFdP = np.array([[ 1j*Y[1]],
+                     [ 1j*Y[0]]])
+
+    return dFdY, dFdP
+
+def boundary_conditions(Ya,Yb,P):
+    BCa = np.array([Ya[0],
+                    Ya[1] - 1.0])
+
+    BCb = np.array([Yb[0]])
+    return BCa, BCb
+
+def boundary_conditions_derivative(Ya, Yb, P):
+    dBCa = np.array([[1.0, 0.0],
+                     [0.0, 1.0]])
+
+    dBCb = np.array([[1.0, 0.0]])
+
+    dBPa = np.zeros((2,1), dtype=complex)
+    dBPb = np.zeros((1,1), dtype=complex)
+    return dBCa, dBCb, dBPa, dBPb
+
+if __name__=='__main__':
+
+    P0 = 5.0
+    if len(sys.argv)==2:
+        P0 = float(sys.argv[1])
+
+    problem = bvp.ComplexProblemDefinition(num_ODE_c = 2,
+                                    num_parameters_c = 1,
+                                    num_left_boundary_conditions_c = 2,
+                                    boundary_points = (0, 2.0*np.pi),
+                                    function_c = function,
+                                    boundary_conditions_c = boundary_conditions,
+                                    function_derivative_c = function_derivative,
+                                    boundary_conditions_derivative_c = boundary_conditions_derivative
+                                    )
+
+    def guess(X, P0):
+        return np.array( [np.sin(P0*X), 0.0, 0.0, -np.cos(P0*X)] )
+
+    initmesh = np.linspace(problem.boundary_points[0],problem.boundary_points[1],512)
+    solution = bvp.solve(problem,
+                        initial_mesh = initmesh,
+                        solution_guess = lambda x: guess(x, P0),
+                        parameter_guess = np.array([P0, 0.0]),
+                        trace = 2)
+
+    x = np.linspace(problem.boundary_points[0],problem.boundary_points[1], 100)
+    y = solution(x)
+    print("lambda = " + str(solution.parameters[0]))
+
+
+    fig = plt.figure()
+    ax = fig.add_subplot(111)
+    ax.plot(x, y[0,:], c='C0')
+    ax.plot(x, y[1,:], c='C0', ls='--')
+    ax.plot(x, y[2,:], c='C1')
+    ax.plot(x, y[3,:], c='C1', ls='--')
+    plt.show()

--- a/scikits/bvp_solver/solver.py
+++ b/scikits/bvp_solver/solver.py
@@ -1,7 +1,7 @@
-import bvp_solverf
+from . import bvp_solverf
 import numpy
-from Solution import Solution
-import tools
+from . import Solution
+from . import tools
 
 def solve(bvp_problem,
           solution_guess,

--- a/scikits/bvp_solver/solver.py
+++ b/scikits/bvp_solver/solver.py
@@ -1,6 +1,6 @@
 from . import bvp_solverf
 import numpy
-from . import Solution
+from .Solution import Solution
 from . import tools
 
 def solve(bvp_problem,
@@ -54,13 +54,13 @@ def solve(bvp_problem,
     init_solution = 0
 
     if isinstance(solution_guess, Solution):
-        if not (initial_mesh == None and
-                parameter_guess == None):
+        if not (initial_mesh is None and
+                parameter_guess is None):
             raise ValueError("values for initial mesh and parameter_guess must not be given if solution_guess is a Solution object")
         init_solution = solution_guess
     else:
 
-        if initial_mesh == None:
+        if initial_mesh is None:
             initial_mesh = numpy.linspace(bvp_problem.boundary_points[0],bvp_problem.boundary_points[1] , 10)
 
         # here we call one of the BVP_GUESS_i routines that make up BVP_INIT to set up the solution

--- a/scikits/bvp_solver/tests/test_examples/test_Example2.py
+++ b/scikits/bvp_solver/tests/test_examples/test_Example2.py
@@ -10,8 +10,8 @@ import scikits.bvp_solver
 import numpy
 from numpy.testing import assert_almost_equal
 import nose
-import example2data as data
-import testing
+from . import example2data as data
+from . import testing
 
 #Results obtained by Ascher/Russell.
 

--- a/scikits/bvp_solver/tests/test_examples/test_Example3.py
+++ b/scikits/bvp_solver/tests/test_examples/test_Example3.py
@@ -7,9 +7,9 @@
 import scikits.bvp_solver
 import numpy
 from numpy.testing import assert_almost_equal
-import example3data as data
+from . import example3data as data
 import nose
-import testing
+from . import testing
 
 
 eps = .1

--- a/scikits/bvp_solver/tests/test_examples/test_Example5.py
+++ b/scikits/bvp_solver/tests/test_examples/test_Example5.py
@@ -9,9 +9,9 @@ import scikits.bvp_solver
 import numpy
 from numpy import array
 from numpy.testing import assert_almost_equal
-import example5data as data
+from . import example5data as data
 import os
-import testing
+from . import testing
 
 #all None values in the code below are dummy values which must be replaced with real values
 


### PR DESCRIPTION
Hi, I resubmit the pull-request as it was submitted from a master branch. Added one more fix for Windows below:

1. Fixed installation with python 3.6 (tested on linux with python 2.7 and 3.6). Currently "python setup.py install" fails on "import" statements.
2. Added an interface for complex BVP (complex differential equations on real axis, e.g., instability problems): ComplexProblemDefinition(). A new example is included. The backend is the same, basically the new interface is a wrapper to double the equations/BCs/parameters.
3. Fixed installation on Windows 10 with ming-w64 gfortran compiler.

Note:
There is no unit-testing routines for the new interface yet.